### PR TITLE
Use clap `Derive` for cleaner command line interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pere"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "4.0.19", features = ["cargo", "wrap_help", "derive"] }
 colors-transform = "0.2.11"
-serde = "1.0.125"
-serde_yaml = "0.8.17"
+regex = "1.7.0"
+serde = "1.0.147"
+serde_yaml = "0.9.14"
 walkdir = "2.3.2"
-regex = "1.4.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,18 +104,19 @@ fn main () {
 	// // }
 
 	// default to current directory
-	let dirname = if let Some(dir) = cli.dir {dir.as_str()} else {"."};
+	let dirname_string = cli.dir.unwrap_or(".".to_string());
+	let dirname = dirname_string.as_str();
 	// let level: usize = DEFAULT_DEPTH
 	// let level: usize = matches.value_of("LEVEL").unwrap_or(DEFAULT_DEPTH).parse().unwrap();
 	// let level: usize = matches.value_of("LEVEL").unwrap_or("")
 
-	let level: usize;
+	// let level: usize;
 
-	if let Some(level) = cli.level {
-		level = level;  // Reset global level (default, 2)
+	let level = if let Some(level) = cli.level {
+		level
 	} else {
-		level = DEFAULT_DEPTH;
-	}
+		DEFAULT_DEPTH
+	};
 
 	// if matches.is_present("DIR") {
 	// }


### PR DESCRIPTION
Tasks:
  - [x] Update dependencies (particularly `clap`), which introduces the `Derive` trait [in v3](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#300---2021-12-31)
  - [x] Use `Derive` trait over ~~`App`~~ [`Command`](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#deprecations).